### PR TITLE
Add timer toggle for practice tests

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -6,6 +6,7 @@ This is a web application for practicing SAT questions.
 
 - Google authentication for user login
 - Protected routes that require authentication
+- Optional timer display while taking tests
 - SAT question browser (upcoming)
 
 ## Setup

--- a/frontend/src/components/TestView.css
+++ b/frontend/src/components/TestView.css
@@ -30,6 +30,26 @@
   border-radius: 8px;
 }
 
+.timer-container {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.timer-toggle {
+  background: none;
+  border: none;
+  color: #3498db;
+  cursor: pointer;
+  font-size: 0.9rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+}
+
+.timer-toggle:hover {
+  text-decoration: underline;
+}
+
 .question-progress {
   font-size: 1rem;
   color: #7f8c8d;

--- a/frontend/src/components/TestView.tsx
+++ b/frontend/src/components/TestView.tsx
@@ -34,6 +34,7 @@ const TestView = ({ tests, fromRetake = false }: TestViewProps) => {
   const [showResults, setShowResults] = useState(false);
   const [reviewMode, setReviewMode] = useState(false);
   const [timeRemaining, setTimeRemaining] = useState<number | null>(null);
+  const [showTimer, setShowTimer] = useState(true);
 
   // State for loading and errors
   const [initialLoading, setInitialLoading] = useState(true);
@@ -623,7 +624,17 @@ const TestView = ({ tests, fromRetake = false }: TestViewProps) => {
             {reviewMode && <div className="review-badge">Review Mode</div>}
 
             {timeRemaining !== null && !showResults && !reviewMode && (
-              <div className="timer">Time: {formatTime(timeRemaining)}</div>
+              <div className="timer-container">
+                {showTimer && (
+                  <div className="timer">Time: {formatTime(timeRemaining)}</div>
+                )}
+                <button
+                  className="timer-toggle"
+                  onClick={() => setShowTimer((prev) => !prev)}
+                >
+                  {showTimer ? "Hide Timer" : "Show Timer"}
+                </button>
+              </div>
             )}
 
             <div className="question-progress">


### PR DESCRIPTION
## Summary
- allow hiding the countdown timer while taking a practice exam
- document optional timer display in the frontend README

## Testing
- `npm run lint` *(fails: couldn't find eslint config)*