### PR TITLE
Switch history cards to table layout

### DIFF
--- a/frontend/src/components/TestHistory.css
+++ b/frontend/src/components/TestHistory.css
@@ -29,69 +29,37 @@
   margin-bottom: 0.5rem;
 }
 
-.attempt-list {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 1rem;
+.history-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
 }
 
-.attempt-card {
+.history-table th,
+.history-table td {
+  padding: 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #e1e8ed;
+}
+
+.history-table th {
   background-color: #f8f9fa;
-  border-radius: 8px;
-  padding: 1rem;
-  border: 1px solid #e1e8ed;
-  transition: all 0.2s ease;
-}
-
-.attempt-card:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
-}
-
-.attempt-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 0.8rem;
-}
-
-.attempt-header h3 {
-  font-size: 1.1rem;
   color: #2c3e50;
-  margin: 0;
   font-weight: 600;
 }
 
+.history-table tbody tr:hover {
+  background-color: #f5f7f9;
+}
+
 .attempt-score {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.score-label {
-  font-size: 0.9rem;
-  color: #7f8c8d;
-}
-
-.score-value {
-  font-size: 1rem;
-  font-weight: 700;
+  font-weight: 600;
   color: #3498db;
-}
-
-.attempt-details {
-  margin-bottom: 1rem;
 }
 
 .attempt-date {
   font-size: 0.85rem;
   color: #7f8c8d;
-  margin-bottom: 0.3rem;
-}
-
-.attempt-progress {
-  font-size: 0.9rem;
-  color: #34495e;
 }
 
 .attempt-actions {

--- a/frontend/src/components/TestHistory.tsx
+++ b/frontend/src/components/TestHistory.tsx
@@ -63,43 +63,35 @@ const TestHistory = () => {
           <p>Take a test to see your history here!</p>
         </div>
       ) : (
-        <div className="attempt-list">
-          {attempts.map(attempt => (
-            <div key={attempt.id} className="attempt-card">
-              <div className="attempt-header">
-                <h3>{attempt.testName}</h3>
-                <div className="attempt-score">
-                  <span className="score-label">Score:</span>
-                  <span className="score-value">{attempt.percentage}%</span>
-                </div>
-              </div>
-              
-              <div className="attempt-details">
-                <p className="attempt-date">
-                  Completed on {formatDate(attempt.completedAt)}
-                </p>
-                <p className="attempt-progress">
-                  {attempt.score} out of {attempt.totalQuestions} questions correct
-                </p>
-              </div>
-              
-              <div className="attempt-actions">
-                <Link
-                  to={`/review/${attempt.id}`}
-                  className="review-button"
-                >
-                  Review Attempt
-                </Link>
-                <Link
-                  to={`/retake/${attempt.id}`}
-                  className="retake-button"
-                >
-                  Retake Test
-                </Link>
-              </div>
-            </div>
-          ))}
-        </div>
+        <table className="history-table">
+          <thead>
+            <tr>
+              <th>Test Name</th>
+              <th>Date</th>
+              <th>Score</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {attempts.map((attempt) => (
+              <tr key={attempt.id}>
+                <td className="test-name">{attempt.testName}</td>
+                <td className="attempt-date">{formatDate(attempt.completedAt)}</td>
+                <td className="attempt-score">
+                  {attempt.score} / {attempt.totalQuestions} ({attempt.percentage}%)
+                </td>
+                <td className="attempt-actions">
+                  <Link to={`/review/${attempt.id}`} className="review-button">
+                    Review
+                  </Link>
+                  <Link to={`/retake/${attempt.id}`} className="retake-button">
+                    Retake
+                  </Link>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- swap the card grid in TestHistory with a table layout
- style the new history table

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: missing script)*