### PR TITLE
Support overtime for practice tests

### DIFF
--- a/backend/API_DOCS.md
+++ b/backend/API_DOCS.md
@@ -202,6 +202,7 @@ Sends an email notification when a test attempt is completed, including test sco
   "testName": "string",
   "score": 8,
   "totalQuestions": 10,
+  "allocatedTime": 600,
   "timeTaken": 300
 }
 ```
@@ -214,6 +215,7 @@ Sends an email notification when a test attempt is completed, including test sco
 - `score` (required): The number of correct answers
 - `totalQuestions` (required): The total number of questions in the test
 - `timeTaken` (required): The time taken to complete the test in seconds
+- `allocatedTime` (required): The time allocated for the test in seconds
 
 **Response:**
 ```json

--- a/backend/EMAIL_DOCS.md
+++ b/backend/EMAIL_DOCS.md
@@ -25,6 +25,7 @@ Sends an email notification when a test attempt is completed, including test sco
   "testName": "string",
   "score": 8,
   "totalQuestions": 10,
+  "allocatedTime": 600,
   "timeTaken": 300
 }
 ```
@@ -36,6 +37,7 @@ Sends an email notification when a test attempt is completed, including test sco
 - `testName` (required): The name of the test
 - `score` (required): The number of correct answers
 - `totalQuestions` (required): The total number of questions in the test
+- `allocatedTime` (required): The time allocated for the test in seconds
 - `timeTaken` (required): The time taken to complete the test in seconds
 
 **Response:**
@@ -75,6 +77,7 @@ async function sendTestAttemptEmail(
   testName: string,
   score: number,
   totalQuestions: number,
+  allocatedTime: number,
   timeTaken: number
 ): Promise<boolean> {
   try {
@@ -90,6 +93,7 @@ async function sendTestAttemptEmail(
         testName,
         score,
         totalQuestions,
+        allocatedTime,
         timeTaken
       }),
     });
@@ -116,6 +120,7 @@ function onTestSubmit() {
     testName,
     score,
     totalQuestions,
+    allocatedTime,
     timeTaken
   );
   

--- a/backend/src/controllers/emailController.ts
+++ b/backend/src/controllers/emailController.ts
@@ -21,6 +21,7 @@ export default {
         testName,
         score,
         totalQuestions,
+        allocatedTime,
         timeTaken,
         wrongAnswers
       } = req.body;
@@ -46,8 +47,8 @@ export default {
         return res.status(400).json({ error: 'Score and totalQuestions are required' });
       }
       
-      if (timeTaken === undefined) {
-        return res.status(400).json({ error: 'Time taken is required' });
+      if (allocatedTime === undefined || timeTaken === undefined) {
+        return res.status(400).json({ error: 'Allocated time and time taken are required' });
       }
       
       // Get user's email and notification preferences
@@ -89,6 +90,7 @@ export default {
         testName,
         score,
         totalQuestions,
+        allocatedTime,
         timeTaken,
         userEmailInfo.email,
         userEmailInfo.notificationEmails,

--- a/backend/src/services/emailService.ts
+++ b/backend/src/services/emailService.ts
@@ -147,6 +147,7 @@ The SAT Practice Team
     testName: string,
     score: number,
     totalQuestions: number,
+    allocatedTime: number,
     timeTaken: number,
     recipientEmail: string,
     additionalEmails: string[] = [],
@@ -169,10 +170,10 @@ The SAT Practice Team
         return false;
       }
 
-      // Format time taken
-      const minutes = Math.floor(timeTaken / 60);
-      const seconds = timeTaken % 60;
-      const timeFormatted = `${minutes}m ${seconds}s`;
+      // Format times
+      const format = (s: number) => `${Math.floor(s / 60)}m ${s % 60}s`;
+      const timeFormatted = format(timeTaken);
+      const allocatedFormatted = format(allocatedTime);
 
       // Calculate percentage score
       const percentage = Math.round((score / totalQuestions) * 100);
@@ -244,6 +245,7 @@ You have completed the SAT practice test "${testName}".
 Test Results:
 - Score: ${score}/${totalQuestions} (${percentage}%)
 - Time Taken: ${timeFormatted}
+- Time Allocated: ${allocatedFormatted}
 
 You can review your answers here: ${reviewUrl}
 Want to try again? Retake the test: ${retakeUrl}
@@ -267,8 +269,9 @@ The SAT Practice Team
         <div style="font-size: 16px;">${percentage}%</div>
       </div>
       <div style="text-align: center; padding: 10px 15px; background-color: white; border-radius: 5px; flex: 1;">
-        <div style="font-size: 14px; color: #666;">Time Taken</div>
+        <div style="font-size: 14px; color: #666;">Time</div>
         <div style="font-size: 24px; font-weight: bold; color: #2c6ecf;">${timeFormatted}</div>
+        <div style="font-size: 14px; color: #666;">Allocated: ${allocatedFormatted}</div>
       </div>
     </div>
   </div>

--- a/frontend/src/components/TestView.css
+++ b/frontend/src/components/TestView.css
@@ -302,6 +302,12 @@ p {
   color: #34495e;
 }
 
+.time-summary {
+  font-size: 1rem;
+  color: #2c3e50;
+  margin-top: 0.5rem;
+}
+
 .results-actions {
   display: flex;
   gap: 1.5rem;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -131,6 +131,7 @@ export const sendTestAttemptEmail = async (
   testName: string,
   score: number,
   totalQuestions: number,
+  allocatedTime: number,
   timeTaken: number,
   wrongAnswers?: WrongAnswer[]
 ): Promise<ApiResponse<{success: boolean, message: string}>> => {
@@ -143,6 +144,7 @@ export const sendTestAttemptEmail = async (
       testName,
       score,
       totalQuestions,
+      allocatedTime,
       timeTaken,
       wrongAnswers
     })

--- a/frontend/src/services/userSettingsService.ts
+++ b/frontend/src/services/userSettingsService.ts
@@ -65,6 +65,7 @@ export const sendTestAttemptNotifications = async (
   testName: string,
   score: number,
   totalQuestions: number,
+  allocatedTime: number,
   timeTaken: number,
   wrongAnswers?: WrongAnswer[]
 ): Promise<boolean> => {
@@ -79,6 +80,7 @@ export const sendTestAttemptNotifications = async (
       testName,
       score,
       totalQuestions,
+      allocatedTime,
       timeTaken,
       wrongAnswers
     );


### PR DESCRIPTION
## Summary
- allow timer to continue past zero and show negative time
- show allocated vs total time on results page
- include allocated time in email notifications
- update API and email docs
- restore auto-save of progress to localStorage

## Testing
- `npm test` (fails: no test specified)
- `npm run lint` (fails: ESLint couldn't find config)
